### PR TITLE
Allow Glue download Hudi Jars & upgrade DMS version to 3.4.7

### DIFF
--- a/PreLab/2-PreLab-DMSlab_student_CFN.yaml
+++ b/PreLab/2-PreLab-DMSlab_student_CFN.yaml
@@ -297,6 +297,24 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
         - arn:aws:iam::aws:policy/AmazonKinesisFullAccess
+      Policies:
+        -
+          PolicyName: DEBucketAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Sid: ListDEBucket
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: arn:aws:s3:::aws-dataengineering-day.workshop.aws
+              -
+                Sid: GetObjectFromDEBucket
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: arn:aws:s3:::aws-dataengineering-day.workshop.aws/*  
   DMSCloudWatchLogRole:
     Type: AWS::IAM::Role
     Condition: DMSCWRoleExist

--- a/PreLab/2-PreLab-autocompleteDMSlab_CFN.yaml
+++ b/PreLab/2-PreLab-autocompleteDMSlab_CFN.yaml
@@ -394,6 +394,7 @@ Resources:
       Path: /service-role/
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+        - arn:aws:iam::aws:policy/AmazonKinesisFullAccess
       Policies:
         -
           PolicyName: DEBucketAccess

--- a/PreLab/2-PreLab-autocompleteDMSlab_CFN.yaml
+++ b/PreLab/2-PreLab-autocompleteDMSlab_CFN.yaml
@@ -394,6 +394,25 @@ Resources:
       Path: /service-role/
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+        - arn:aws:iam::aws:policy/AmazonKinesisFullAccess
+      Policies:
+        -
+          PolicyName: DEBucketAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Sid: ListDEBucket
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: arn:aws:s3:::aws-dataengineering-day.workshop.aws
+              -
+                Sid: GetObjectFromDEBucket
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: arn:aws:s3:::aws-dataengineering-day.workshop.aws/*
   DMSCloudWatchLogRole:
     Type: AWS::IAM::Role
     Condition: DMSCWRoleExist
@@ -539,7 +558,7 @@ Resources:
         !Ref DMSReplicationSubnetGroup
       PreferredMaintenanceWindow: sat:05:40-sat:06:10
       MultiAZ: false
-      EngineVersion: 3.4.4
+      EngineVersion: 3.4.7
       AutoMinorVersionUpgrade: true
       PubliclyAccessible: true
   DMSEndpointSource:

--- a/PreLab/2-PreLab-autocompleteDMSlab_CFN.yaml
+++ b/PreLab/2-PreLab-autocompleteDMSlab_CFN.yaml
@@ -394,7 +394,6 @@ Resources:
       Path: /service-role/
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
-        - arn:aws:iam::aws:policy/AmazonKinesisFullAccess
       Policies:
         -
           PolicyName: DEBucketAccess
@@ -547,6 +546,7 @@ Resources:
         - !Ref dmslabstudentsubnet1
         - !Ref dmslabstudentsubnet2
   DMSReplicationInstance:
+    DependsOn: gw1
     Type: AWS::DMS::ReplicationInstance
     Properties:
       ReplicationInstanceIdentifier: dmsreplication-instance


### PR DESCRIPTION
[*ISSUE 27*](https://github.com/aws-samples/data-engineering-for-aws-immersion-day/issues/27)

*Glue lab IAM role doesn't have permission to download Hudi Jars*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
